### PR TITLE
Center header and hero and add public assets folder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import './framer/styles.css'
 
 import HeroFramerComponent from './framer/hero'
+import NavbarFramerComponent from './framer/navbar'
 import AboutFramerComponent from './framer/about'
 import ProjekteFramerComponent from './framer/projekte'
 import ServicesFramerComponent from './framer/services'
@@ -10,7 +11,10 @@ import BlogsFramerComponent from './framer/blogs'
 export default function App() {
   return (
     <div className='flex flex-col w-full bg-[rgb(245,_241, 229)]'>
-      <HeroFramerComponent.Responsive/>
+      <div className='relative w-full'>
+        <HeroFramerComponent.Responsive className='flex flex-col items-center text-center pt-20 pb-32'/>
+        <NavbarFramerComponent.Responsive className='absolute top-0 left-1/2 -translate-x-1/2 w-full flex justify-center'/>
+      </div>
       <div className='flex flex-col items-center gap-3'>
         <AboutFramerComponent.Responsive/>
         <ProjekteFramerComponent.Responsive/>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,28 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Layout overrides for centered hero and responsive header */
+.framer-d9hw3d {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.framer-17y5v30 {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.framer-6jl1q8,
+.framer-1d8rgyn,
+.framer-9wme8j {
+  text-align: center;
+}
+
+.framer-9wme8j {
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
- add empty `public` directory for future static assets
- position responsive navbar over the hero and center hero content
- add CSS overrides to keep header responsive and center title, subtitle, and button

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a59af6c70832da06721199dd9724d