### PR TITLE
feat: add german landing page and tax calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="de">
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Unframer + Vite + React + TS</title>
+        <title>MSH Dresden – Kapitalanlage in Denkmalobjekte</title>
     </head>
     <body>
         <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,26 @@
-import './framer/styles.css'
-
-import HeroFramerComponent from './framer/hero'
-import NavbarFramerComponent from './framer/navbar'
-import AboutFramerComponent from './framer/about'
-import ProjekteFramerComponent from './framer/projekte'
-import ServicesFramerComponent from './framer/services'
-import CtaFramerComponent from './framer/cta'
-import BlogsFramerComponent from './framer/blogs'
+import React from 'react'
+import Hero from './components/Hero'
+import About from './components/About'
+import Projekte from './components/Projekte'
+import Services from './components/Services'
+import Steuerrechner from './components/Steuerrechner'
+import Blogs from './components/Blogs'
+import CTA from './components/CTA'
+import Footer from './components/Footer'
 
 export default function App() {
   return (
-    <div className='flex flex-col w-full bg-[rgb(245,_241, 229)]'>
-      <div className='relative w-full'>
-        <HeroFramerComponent.Responsive className='flex flex-col items-center text-center pt-20 pb-32'/>
-        <NavbarFramerComponent.Responsive className='absolute top-0 left-1/2 -translate-x-1/2 w-full flex justify-center'/>
-      </div>
-      <div className='flex flex-col items-center gap-3'>
-        <AboutFramerComponent.Responsive/>
-        <ProjekteFramerComponent.Responsive/>
-        <ServicesFramerComponent.Responsive/>
-        <BlogsFramerComponent.Responsive/>
-      </div>
-      <CtaFramerComponent.Responsive/>
+    <div className='flex flex-col min-h-screen w-full bg-[rgb(245,_241,229)]'>
+      <Hero />
+      <main className='flex-1 flex flex-col items-center gap-3 w-full'>
+        <About />
+        <Projekte />
+        <Services />
+        <Steuerrechner />
+        <Blogs />
+      </main>
+      <CTA />
+      <Footer />
     </div>
-  );
-};
+  )
+}

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export default function About() {
+  return (
+    <section id="about" className="py-16 px-4 text-center max-w-4xl">
+      <h2 className="text-3xl font-bold mb-4">Über MSH Dresden</h2>
+      <p>
+        MSH Dresden ist spezialisiert auf die Sanierung und Vermarktung denkmalgeschützter
+        Immobilien als Kapitalanlage. Unsere Objekte in Bestlage vereinen historische Substanz
+        mit moderner Technik und bieten attraktive steuerliche Vorteile durch die Abschreibung
+        für Abnutzung (AfA).
+      </p>
+    </section>
+  )
+}

--- a/src/components/Blogs.tsx
+++ b/src/components/Blogs.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export default function Blogs() {
+  return (
+    <section id="blogs" className="py-16 px-4 max-w-5xl mx-auto">
+      <h2 className="text-3xl font-bold text-center mb-8">Aktuelles</h2>
+      <div className="grid md:grid-cols-3 gap-6">
+        <article>
+          <h3 className="font-semibold text-xl">Steuerliche Vorteile von Denkmalimmobilien</h3>
+          <p className="mt-2 text-sm">Erfahren Sie, wie Sie mit der AfA Ihre Steuerlast senken können.</p>
+        </article>
+        <article>
+          <h3 className="font-semibold text-xl">MSH Projekt Königstraße</h3>
+          <p className="mt-2 text-sm">Ein Blick hinter die Kulissen unserer aktuellen Sanierung.</p>
+        </article>
+        <article>
+          <h3 className="font-semibold text-xl">Warum Dresden?</h3>
+          <p className="mt-2 text-sm">Die sächsische Hauptstadt als Standort für langfristige Kapitalanlagen.</p>
+        </article>
+      </div>
+    </section>
+  )
+}

--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function CTA() {
+  return (
+    <section id="kontakt" className="py-16 bg-gray-100 flex flex-col items-center text-center px-4">
+      <h2 className="text-3xl font-bold mb-4">Interesse geweckt?</h2>
+      <p className="mb-6">Kontaktieren Sie uns für eine individuelle Beratung zu unseren Denkmalobjekten.</p>
+      <a href="mailto:info@msh-dresden.de" className="bg-blue-600 text-white px-6 py-3 rounded">Jetzt anfragen</a>
+    </section>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Footer() {
+  return (
+    <footer className="bg-black text-white text-center py-6 mt-auto">
+      <p className="text-sm">&copy; {new Date().getFullYear()} MSH Dresden. Alle Rechte vorbehalten.</p>
+    </footer>
+  )
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import Navbar from './Navbar'
+
+export default function Hero() {
+  return (
+    <section id="hero" className="relative flex items-center justify-center text-center min-h-screen bg-cover bg-center bg-[url('https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1950&q=80')]">
+      <div className="absolute top-0 left-1/2 -translate-x-1/2">
+        <Navbar />
+      </div>
+      <div className="mt-32 max-w-2xl px-4">
+        <h1 className="text-4xl md:text-6xl font-bold text-white">
+          Kapitalanlage in MSH Dresden
+        </h1>
+        <p className="mt-4 text-xl text-white">
+          Denkmalgeschützte Immobilien mit steuerlicher AfA
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export default function Navbar() {
+  return (
+    <nav className="flex gap-6 text-white font-semibold py-4">
+      <a href="#about" className="hover:underline">Über uns</a>
+      <a href="#projekte" className="hover:underline">Projekte</a>
+      <a href="#services" className="hover:underline">Leistungen</a>
+      <a href="#steuerrechner" className="hover:underline">Steuerrechner</a>
+      <a href="#blogs" className="hover:underline">Blog</a>
+      <a href="#kontakt" className="hover:underline">Kontakt</a>
+    </nav>
+  )
+}

--- a/src/components/Projekte.tsx
+++ b/src/components/Projekte.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export default function Projekte() {
+  return (
+    <section id="projekte" className="py-16 w-full bg-white flex flex-col items-center">
+      <h2 className="text-3xl font-bold mb-8">Denkmal-Objekte</h2>
+      <div className="grid md:grid-cols-3 gap-8 px-4 max-w-5xl">
+        <div className="bg-gray-100 p-4 rounded shadow">
+          <h3 className="font-semibold">Villa am Großen Garten</h3>
+          <p className="text-sm mt-2">Sanierter Altbau mit 5 Wohnungen in unmittelbarer Nähe zur Elbe.</p>
+        </div>
+        <div className="bg-gray-100 p-4 rounded shadow">
+          <h3 className="font-semibold">Wohnhaus Königstraße</h3>
+          <p className="text-sm mt-2">Charmantes Gründerzeitobjekt im Barockviertel.</p>
+        </div>
+        <div className="bg-gray-100 p-4 rounded shadow">
+          <h3 className="font-semibold">Lofts im Industriegelände</h3>
+          <p className="text-sm mt-2">Ehemalige Fabrik, umgewandelt in moderne Loftwohnungen.</p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export default function Services() {
+  return (
+    <section id="services" className="py-16 px-4 max-w-5xl mx-auto">
+      <h2 className="text-3xl font-bold text-center mb-8">Unsere Leistungen</h2>
+      <div className="grid md:grid-cols-3 gap-6">
+        <div className="text-center">
+          <h3 className="font-semibold text-xl">Kapitalanlage</h3>
+          <p className="mt-2 text-sm">Wir beraten Sie bei der Auswahl renditestarker Immobilien in Dresden.</p>
+        </div>
+        <div className="text-center">
+          <h3 className="font-semibold text-xl">Denkmal-Sanierung</h3>
+          <p className="mt-2 text-sm">Historische Gebäude werden von uns mit höchster Sorgfalt modernisiert.</p>
+        </div>
+        <div className="text-center">
+          <h3 className="font-semibold text-xl">Steuerliche AfA</h3>
+          <p className="mt-2 text-sm">Nutzen Sie die erhöhten Abschreibungen für denkmalgeschützte Objekte.</p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/Steuerrechner.tsx
+++ b/src/components/Steuerrechner.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react'
+
+export default function Steuerrechner() {
+  const [price, setPrice] = useState('')
+  const [afa, setAfa] = useState('2')
+  const [taxRate, setTaxRate] = useState('30')
+  const [years, setYears] = useState('10')
+
+  const priceNum = parseFloat(price) || 0
+  const afaRate = parseFloat(afa) || 0
+  const taxRateNum = parseFloat(taxRate) || 0
+  const yearsNum = parseInt(years) || 0
+
+  const yearlyAfa = priceNum * afaRate / 100
+  const yearlySavings = yearlyAfa * taxRateNum / 100
+  const totalSavings = yearlySavings * yearsNum
+
+  const format = (n: number) => n.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' })
+
+  return (
+    <section id="steuerrechner" className="py-16 bg-white w-full flex flex-col items-center">
+      <h2 className="text-3xl font-bold mb-8">Steuerrechner</h2>
+      <div className="grid gap-4 w-full max-w-md">
+        <input type="number" value={price} onChange={e => setPrice(e.target.value)} placeholder="Kaufpreis (€)" className="border p-2 rounded" />
+        <input type="number" value={afa} onChange={e => setAfa(e.target.value)} placeholder="AfA-Satz (%)" className="border p-2 rounded" />
+        <input type="number" value={taxRate} onChange={e => setTaxRate(e.target.value)} placeholder="Einkommensteuersatz (%)" className="border p-2 rounded" />
+        <input type="number" value={years} onChange={e => setYears(e.target.value)} placeholder="Laufzeit (Jahre)" className="border p-2 rounded" />
+      </div>
+      <div className="mt-6 text-center">
+        <p>Jährliche AfA: {format(yearlyAfa)}</p>
+        <p>Steuerersparnis pro Jahr: {format(yearlySavings)}</p>
+        <p>Steuerersparnis gesamt: {format(totalSavings)}</p>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- Translate landing page and components into German focusing on MSH Dresden and Kapitalanlage
- Add steuerlicher AfA section and interactive tax calculator component
- Place navigation inside hero and footer at bottom

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a5ec46514832d9710de59d1a70620