### PR TITLE
Refine Steuerrechner section and translate nav

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ export default function Navbar() {
       <a href="#projekte" className="hover:underline">Projekte</a>
       <a href="#services" className="hover:underline">Leistungen</a>
       <a href="#steuerrechner" className="hover:underline">Steuerrechner</a>
-      <a href="#blogs" className="hover:underline">Blog</a>
+      <a href="#blogs" className="hover:underline">Aktuelles</a>
       <a href="#kontakt" className="hover:underline">Kontakt</a>
     </nav>
   )

--- a/src/components/Steuerrechner.tsx
+++ b/src/components/Steuerrechner.tsx
@@ -18,18 +18,44 @@ export default function Steuerrechner() {
   const format = (n: number) => n.toLocaleString('de-DE', { style: 'currency', currency: 'EUR' })
 
   return (
-    <section id="steuerrechner" className="py-16 bg-white w-full flex flex-col items-center">
-      <h2 className="text-3xl font-bold mb-8">Steuerrechner</h2>
-      <div className="grid gap-4 w-full max-w-md">
-        <input type="number" value={price} onChange={e => setPrice(e.target.value)} placeholder="Kaufpreis (€)" className="border p-2 rounded" />
-        <input type="number" value={afa} onChange={e => setAfa(e.target.value)} placeholder="AfA-Satz (%)" className="border p-2 rounded" />
-        <input type="number" value={taxRate} onChange={e => setTaxRate(e.target.value)} placeholder="Einkommensteuersatz (%)" className="border p-2 rounded" />
-        <input type="number" value={years} onChange={e => setYears(e.target.value)} placeholder="Laufzeit (Jahre)" className="border p-2 rounded" />
-      </div>
-      <div className="mt-6 text-center">
-        <p>Jährliche AfA: {format(yearlyAfa)}</p>
-        <p>Steuerersparnis pro Jahr: {format(yearlySavings)}</p>
-        <p>Steuerersparnis gesamt: {format(totalSavings)}</p>
+    <section id="steuerrechner" className="py-16 w-full bg-white">
+      <div className="max-w-5xl mx-auto px-4 flex flex-col items-center">
+        <h2 className="text-3xl font-bold text-center mb-8">Steuerrechner</h2>
+        <div className="grid gap-4 w-full max-w-md">
+          <input
+            type="number"
+            value={price}
+            onChange={e => setPrice(e.target.value)}
+            placeholder="Kaufpreis (€)"
+            className="border p-2 rounded"
+          />
+          <input
+            type="number"
+            value={afa}
+            onChange={e => setAfa(e.target.value)}
+            placeholder="AfA-Satz (%)"
+            className="border p-2 rounded"
+          />
+          <input
+            type="number"
+            value={taxRate}
+            onChange={e => setTaxRate(e.target.value)}
+            placeholder="Einkommensteuersatz (%)"
+            className="border p-2 rounded"
+          />
+          <input
+            type="number"
+            value={years}
+            onChange={e => setYears(e.target.value)}
+            placeholder="Laufzeit (Jahre)"
+            className="border p-2 rounded"
+          />
+        </div>
+        <div className="mt-6 text-center">
+          <p>Jährliche AfA: {format(yearlyAfa)}</p>
+          <p>Steuerersparnis pro Jahr: {format(yearlySavings)}</p>
+          <p>Steuerersparnis gesamt: {format(totalSavings)}</p>
+        </div>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- Localize nav link text to "Aktuelles" for a fully German interface
- Style Steuerrechner section with centered layout consistent with other sections

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b0f2b8e3c832d9f99efbe95fdbfae